### PR TITLE
update readme, added sorry exit, and exposed newplayer

### DIFF
--- a/templates/basic/Readme.md
+++ b/templates/basic/Readme.md
@@ -2,9 +2,9 @@
 
 _This project was generated with [create-empirica-app](https://github.com/empiricaly/create-empirica-app)._
 
-*Add a description of your study*
+*Add a description of your Empirica app*
 
-# Testing this App Locally
+# Running this App Locally
 
 ## General  Setup
 If you haven't already:
@@ -14,14 +14,13 @@ If you haven't already:
 
 ## Preparing this app
 
-Clone this repository to a local repository on your device.
-In the command line run this to install all the Node packages:
+If you have just downloaded, pulled, or cloned this app, you should run this in the command line to install all the Node packages:
 
 ```
 meteor npm install
 ```
 
-## Running the app locally
+## Launching the app
 
 You can now run the app on your local machine with:
 
@@ -53,8 +52,8 @@ To run a game create a new `batch` with the games of treatments you want to use 
 Open a player tab by going to [https:/localhost:3000/](https:/localhost:3000/) or clicking on **open app**.
 
 The player that you open with [https:/localhost:3000/](https:/localhost:3000/) is cached on your browser. Whenever you start a game with this player, your local app will keep that information. To play again there are multiple things you can do:
-- Click on the **Reset current session** button on header of a tab with your player to reset this player, and create a new game for this player to join.
-- Click on the **New Player** button on header of a tab with your player to open a new tab with a different player (you will see tab with an id).
+- Click on the **Reset current session** button on the header of a tab with your player to reset this player, and create a new game for this player to join.
+- Click on the **New Player** button on the header of a tab with your player to open a new tab with a different player (you will see the id of that player in the title of the tab).
 - Go to the **Players** tab in the admin panel and retire players that have finished or cancelled.
 
 **The app will hot reload as you save changes to your code.**

--- a/templates/basic/Readme.md
+++ b/templates/basic/Readme.md
@@ -94,6 +94,8 @@ callbacks, such as `onRoundEnd`, offer powerful ways to add logic to a game in a
 central point (the server), which is often preferable to adding all the logic on
 the client.
 
+Finally, the /server/bots.js file is where you can add bot definitions to your app.
+
 ## Public
 
 The `/public` is here to host any static assets you might need in the game, such

--- a/templates/basic/Readme.md
+++ b/templates/basic/Readme.md
@@ -2,22 +2,66 @@
 
 _This project was generated with [create-empirica-app](https://github.com/empiricaly/create-empirica-app)._
 
-## Getting started
+*Add a description of your study*
 
-To run this project locally, run the local server:
+# Testing this App Locally
 
-```sh
-meteor
+## General  Setup
+If you haven't already:
+
+- Install `Node.js` and `npm` here: [https://nodejs.org/en/](https://nodejs.org/en/)
+- Install `Meteor` here: [https://www.meteor.com/install](https://www.meteor.com/install)
+
+## Preparing this app
+
+Clone this repository to a local repository on your device.
+In the command line run this to install all the Node packages:
+
+```
+meteor npm install
 ```
 
-## Introduction
+## Running the app locally
 
-Your Empirica experiment is built with [Meteor](https://www.meteor.com/) web
-development framework. All your code will be split in 2 main categories: code
-running on the **client** (the browser) and code running on the **server**.
-This functional seperation is immediately reflected in the folders structure.
+You can now run the app on your local machine with:
 
-### Client
+```
+meteor
+```
+This can take a few minutes.
+
+This will start the app that you can access as a participant:
+[https:/localhost:3000/](https:/localhost:3000/)
+
+You can access the admin panel here:
+[https:/localhost:3000/admin](https:/localhost:3000/admin)
+
+Log in with the *username* and *password* provided in the command line.
+
+## Loading the factors and treatments
+
+To use the app, you usually need to use treatments and factors. Some might be prepared in a `.yaml` file (e.g., `factors.yaml`). In the **admin panel**:
+- click on the **Configuration** button
+- click on **import**
+- select the `.yaml` file you want to import the factors and treatments from
+- wait a few seconds for the factors and treatments to be imported
+
+## Testing the app
+
+To run a game create a new `batch` with the games of treatments you want to use and click start on the batch.
+
+Open a player tab by going to [https:/localhost:3000/](https:/localhost:3000/) or clicking on **open app**.
+
+The player that you open with [https:/localhost:3000/](https:/localhost:3000/) is cached on your browser. Whenever you start a game with this player, your local app will keep that information. To play again there are multiple things you can do:
+- Click on the **Reset current session** button on header of a tab with your player to reset this player, and create a new game for this player to join.
+- Click on the **New Player** button on header of a tab with your player to open a new tab with a different player (you will see tab with an id).
+- Go to the **Players** tab in the admin panel and retire players that have finished or cancelled.
+
+**The app will hot reload as you save changes to your code.**
+
+# Structure of the App
+
+## Client
 
 All code in the `/client` directory will be ran on the client. The entry point
 for your app on the client can be found in `/client/main.js`. In there you will
@@ -38,7 +82,7 @@ The `/client/game`, `/client/intro`, `/client/exit` directories all contain
 If you are new to React, we recommend you try out the official
 [React Tutorial](https://reactjs.org/tutorial/tutorial.html).
 
-### Server
+## Server
 
 Server-side code all starts in the `/server/main.js` file. In that file, we set
 an important Empirica integration point, the `Empirica.gameInit`, which allows
@@ -50,40 +94,17 @@ callbacks, such as `onRoundEnd`, offer powerful ways to add logic to a game in a
 central point (the server), which is often preferable to adding all the logic on
 the client.
 
-Finally, the `/server/bots.js` file is where you can add bot definitions
-to your app.
-
-### Public
+## Public
 
 The `/public` is here to host any static assets you might need in the game, such
 as images. For example, if you add an image at `/public/my-logo.jpeg`, it will
 be available in the app at `http://localhost:3000/my-logo.jpeg`.
 
-### Settings
+# Learn more
 
-We generated a basic settings file (`/local.json`), which should originally only
-contain configuration for admin login. More documentation for settings is coming
-soon.
-
-You can run the app with the settings like this:
-
-```sh
-meteor --settings local.json
-```
-
-## Updating Empirica Core
-
-As new versions of Empirica become available, you might want to update the
-version you are using in your app. To do so, simply run:
-
-```sh
-meteor update empirica:core
-```
-
-## Learn more
-
-- Empirica Website: https://empirica.ly/
-- Meteor Tutorial: https://www.meteor.com/tutorials/react/creating-an-app
-- React Tutorial: https://reactjs.org/tutorial/tutorial.html
-- LESS Intro: http://lesscss.org/#overview
-- JavaScript Tutorial: https://javascript.info/
+- Empirica Website: [https://empirica.ly/](https://empirica.ly/)
+- Empirica documentation: [https://docs.empirica.ly/](https://docs.empirica.ly/)
+- Meteor Tutorial: [https://www.meteor.com/tutorials/react/creating-an-app](https://www.meteor.com/tutorials/react/creating-an-app)
+- React Tutorial: [https://reactjs.org/tutorial/tutorial.html](https://reactjs.org/tutorial/tutorial.html)
+- LESS Intro: [http://lesscss.org/#overview](http://lesscss.org/#overview)
+- JavaScript Tutorial: [https://javascript.info/](https://javascript.info/)

--- a/templates/basic/client/exit/Sorry.jsx
+++ b/templates/basic/client/exit/Sorry.jsx
@@ -1,0 +1,47 @@
+import React, { Component } from 'react'
+import { Meteor } from "meteor/meteor";
+import { Centered } from "meteor/empirica:core";
+
+export default class Sorry extends Component {
+    static stepName = "Sorry";
+
+    render() {
+        const { player, game } = this.props;
+        let msg;
+        switch (player.exitStatus) {
+            case "gameFull":
+                msg = "All games you are eligible for have filled up too fast...";
+                break;
+            case "gameLobbyTimedOut":
+                msg = "There were NOT enough players for the game to start...";
+                break;
+            case "playerEndedLobbyWait":
+                msg =
+                    "You decided to stop waiting, we are sorry it was too long a wait.";
+                break;
+            default:
+                msg = "Unfortunately the Game was cancelled...";
+                break;
+        }
+        if (player.exitReason === "failedQuestion") {
+            msg =
+                "Unfortunately you did not meet the conditions required to play the game.";
+        }
+        // Only for dev
+        if (!game && Meteor.isDevelopment) {
+            msg =
+                "Unfortunately the Game was cancelled because of failed to init Game (only visible in development, check the logs).";
+        }
+        return (
+            <Centered>
+                <div>
+                    <h4>Sorry!</h4>
+                    <p>Sorry, you were not able to play today! {msg}</p>
+                    <p>
+                        <strong>Please contact the researcher to see if there are more games available.</strong>
+                    </p>
+                </div>
+            </Centered>
+        );
+    }
+}

--- a/templates/basic/client/intro/NewPlayer.jsx
+++ b/templates/basic/client/intro/NewPlayer.jsx
@@ -2,54 +2,54 @@ import React, { Component } from 'react'
 import { Centered } from "meteor/empirica:core";
 
 export default class NewPlayer extends Component {
-    state = { id: "" };
+  state = { id: "" };
 
-    handleUpdate = event => {
-        const { value, name } = event.currentTarget;
-        this.setState({ [name]: value });
-    };
+  handleUpdate = event => {
+    const { value, name } = event.currentTarget;
+    this.setState({ [name]: value });
+  };
 
-    handleSubmit = event => {
-        event.preventDefault();
+  handleSubmit = event => {
+    event.preventDefault();
 
-        const { handleNewPlayer } = this.props;
-        const { id } = this.state;
-        handleNewPlayer(id);
-    };
+    const { handleNewPlayer } = this.props;
+    const { id } = this.state;
+    handleNewPlayer(id);
+  };
 
-    render() {
-        const { id } = this.state;
+  render() {
+    const { id } = this.state;
 
-        return (
-            <Centered>
-                <div >
-                    <form onSubmit={this.handleSubmit}>
-                        <h1>Identification</h1>
+    return (
+      <Centered>
+        <div >
+          <form onSubmit={this.handleSubmit}>
+            <h1>Identification</h1>
 
-                        <p>
-                            Please enter your id:
+            <p>
+              Please enter your id:
                         </p>
 
-                        <input
-                            dir="auto"
-                            type="text"
-                            name="id"
-                            id="id"
-                            value={id}
-                            onChange={this.handleUpdate}
-                            required
-                            autoComplete="off"
-                        />
+            <input
+              dir="auto"
+              type="text"
+              name="id"
+              id="id"
+              value={id}
+              onChange={this.handleUpdate}
+              required
+              autoComplete="off"
+            />
 
-                        <br />
+            <br />
 
-                        <p>
-                            <button type="submit">Submit</button>
-                        </p>
+            <p>
+              <button type="submit">Submit</button>
+            </p>
 
-                    </form>
-                </div>
-            </Centered>
-        )
-    }
+          </form>
+        </div>
+      </Centered>
+    )
+  }
 }

--- a/templates/basic/client/intro/NewPlayer.jsx
+++ b/templates/basic/client/intro/NewPlayer.jsx
@@ -1,0 +1,55 @@
+import React, { Component } from 'react'
+import { Centered } from "meteor/empirica:core";
+
+export default class NewPlayer extends Component {
+    state = { id: "" };
+
+    handleUpdate = event => {
+        const { value, name } = event.currentTarget;
+        this.setState({ [name]: value });
+    };
+
+    handleSubmit = event => {
+        event.preventDefault();
+
+        const { handleNewPlayer } = this.props;
+        const { id } = this.state;
+        handleNewPlayer(id);
+    };
+
+    render() {
+        const { id } = this.state;
+
+        return (
+            <Centered>
+                <div >
+                    <form onSubmit={this.handleSubmit}>
+                        <h1>Identification</h1>
+
+                        <p>
+                            Please enter your id:
+                        </p>
+
+                        <input
+                            dir="auto"
+                            type="text"
+                            name="id"
+                            id="id"
+                            value={id}
+                            onChange={this.handleUpdate}
+                            required
+                            autoComplete="off"
+                        />
+
+                        <br />
+
+                        <p>
+                            <button type="submit">Submit</button>
+                        </p>
+
+                    </form>
+                </div>
+            </Centered>
+        )
+    }
+}

--- a/templates/basic/client/main.js
+++ b/templates/basic/client/main.js
@@ -2,6 +2,7 @@ import Empirica from "meteor/empirica:core";
 import { render } from "react-dom";
 import ExitSurvey from "./exit/ExitSurvey";
 import Thanks from "./exit/Thanks";
+import Sorry from "./exit/Sorry";
 import About from "./game/About";
 import Round from "./game/Round";
 import Consent from "./intro/Consent";

--- a/templates/basic/client/main.js
+++ b/templates/basic/client/main.js
@@ -8,12 +8,16 @@ import Consent from "./intro/Consent";
 import InstructionStepOne from "./intro/InstructionStepOne";
 import InstructionStepTwo from "./intro/InstructionStepTwo";
 import Quiz from "./intro/Quiz";
+import NewPlayer from "./intro/NewPlayer";
 
 // Set the About Component you want to use for the About dialog (optional).
 Empirica.about(About);
 
 // Set the Consent Component you want to present players (optional).
 Empirica.consent(Consent);
+
+// Set the component for getting the player id (optional)
+Empirica.newPlayer(NewPlayer);
 
 // Introduction pages to show before they play the game (optional).
 // At this point they have been assigned a treatment. You can return
@@ -41,6 +45,14 @@ Empirica.round(Round);
 // If you don't return anything, or do not define this function, a default
 // exit screen will be shown.
 Empirica.exitSteps((game, player) => {
+  if (
+    !game ||
+    (player.exitStatus &&
+      player.exitStatus !== "finished" &&
+      player.exitReason !== "playerQuit")
+  ) {
+    return [Sorry];
+  }
   return [ExitSurvey, Thanks];
 });
 


### PR DESCRIPTION
Hello, 
Since I started using Empirica I have seen some nice updates come through and I have started to get a better idea of what information is useful for new users or for myself whenever I create a new app. 

I propose these changes for the create-empirica-app:
- A readme file that explains a lot more about running the app, rather than just explaining the content structure of the app.
- Exposing the NewPlayer component that is super useful to modify (and useful for anyone who does not want emails or MIDs) - also made it neutral to the type of id.
- Added the a Sorry component, inspired by the really useful one in the taskbank. This allows researchers to put their contact information there, and gives more information to players if there's a problem with the app.

Note, I don't really know how this work, I assume that if I change the template it will change it when running the command.
